### PR TITLE
Only send a release URL

### DIFF
--- a/src/handlers/github_webhooks.story
+++ b/src/handlers/github_webhooks.story
@@ -1,8 +1,10 @@
 http server as server
   when server listen path: "/github/storyscript/release" method: "post" as req
     if req.headers["X-Github-Event"] == "release" and ! req.body["release"]["draft"]
-      name = req.body["release"]["tag_name"]
-      body = req.body["release"]["body"]
+      release = req.body["release"]
+      tag_name = release["tag_name"]
+      full_name = req.body["repository"]["full_name"]
+      release_notes = "https://github.com/{full_name}/releases/tag/{tag_name}"
       http fetch method: "post" url: app.secrets.slack_webhook_channel_storyscript
                 headers: {"Content-Type": "application/json"}
-                body: {"text": "New Storyscript release - {name}\n\n{body}"}
+                body: {"text": "New Storyscript release - {tag_name}\n\n{release_notes}"}


### PR DESCRIPTION
The full description is a bit too long especially with `<detail>` not being filtered out yet.


Payload example:

```json
{
  "action": "edited",
   ...
  "release": {
    "url": "https://api.github.com/repos/storyscript/storyscript/releases/16803898",
    "assets_url": "https://api.github.com/repos/storyscript/storyscript/releases/16803898/assets",
    "upload_url": "https://uploads.github.com/repos/storyscript/storyscript/releases/16803898/assets{?name,label}",
    "html_url": "https://github.com/storyscript/storyscript/releases/tag/untagged-b80ea272418186618944",
    "tag_name": "0.18.0",
    "target_commitish": "master",
    "name": "Version 0.18.0",
    "draft": true,
    "author": {
      "login": "wilzbach",
      "avatar_url": "https://avatars3.githubusercontent.com/u/4370550?v=4",
      "gravatar_id": "",
      "url": "https://api.github.com/users/wilzbach",
      "html_url": "https://github.com/wilzbach",
      "followers_url": "https://api.github.com/users/wilzbach/followers",
      "following_url": "https://api.github.com/users/wilzbach/following{/other_user}",
      "gists_url": "https://api.github.com/users/wilzbach/gists{/gist_id}",
      "starred_url": "https://api.github.com/users/wilzbach/starred{/owner}{/repo}",
      "subscriptions_url": "https://api.github.com/users/wilzbach/subscriptions",
      "organizations_url": "https://api.github.com/users/wilzbach/orgs",
      "repos_url": "https://api.github.com/users/wilzbach/repos",
      "events_url": "https://api.github.com/users/wilzbach/events{/privacy}",
      "received_events_url": "https://api.github.com/users/wilzbach/received_events",
      "type": "User",
      "site_admin": false
    },
    "prerelease": false,
    "created_at": "2019-04-16T18:47:20Z",
    "published_at": null,
    "assets": [

    ],
    "tarball_url": null,
    "zipball_url": null,
  "repository": {
    "name": "storyscript",
    "full_name": "storyscript/storyscript",
    ...
  }
}
```